### PR TITLE
<Fix> remove click event listener in onclick prop

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -7,7 +7,6 @@ def(() => class extends Jinkela {
   set onclick(handler) {
     if (this.onClick) return;
     this.onClick = handler;
-    this.element.addEventListener('click', event => this.click(event));
   }
   static cast(list, ...args) {
     list = list.map(item => new this(item, ...args));


### PR DESCRIPTION
@YanagiEiichi 

- 移除 onclick 中的点击事件绑定