### PR TITLE
<Fix> use image natural height&width

### DIFF
--- a/src/components/InputFileToken.js
+++ b/src/components/InputFileToken.js
@@ -35,7 +35,7 @@ def((Button) => {
           this.element.style.display = 'inline-block';
           this.element.href = url;
           this.img.onload = () => {
-            this.info = { width: this.img.width, height: this.img.height };
+            this.info = { width: this.img.naturalWidth, height: this.img.naturalHeight };
           };
           this.img.src = url;
         });


### PR DESCRIPTION
@YanagiEiichi 图片预览上有 CSS: `{ width: 28px, height: 28px }`，改用 naturalWidth/naturalHeight 替代，兼容性看起来可以（IE11）。

![image](https://cloud.githubusercontent.com/assets/8141958/23355390/6ef92db0-fd10-11e6-9de7-c319b2526e20.png)
