### PR TITLE
fix: enforce hashchange in ListFilters

### DIFF
--- a/src/components/ListFilters.js
+++ b/src/components/ListFilters.js
@@ -155,7 +155,14 @@ def((Input, Output, Item, Button, ButtonHollow) => {
         }
       });
       uParams.where = JSON.stringify(where);
+
+      let oldHash = location.hash;
       location.hash = new UParams(uParams);
+
+      // enforce hash change
+      if (oldHash === location.hash) {
+        dispatchEvent(new Event('hashchange'));
+      }
     }
     reset() {
       let { uParams, scheme } = this.depot;


### PR DESCRIPTION
遇到的问题是：用户想要点“筛选”后（筛选条件不变）刷新表格数据
一哥帮忙看下可不可以这样做，有没有更好的办法？thx